### PR TITLE
Add more information about detected issues

### DIFF
--- a/kubestalk.py
+++ b/kubestalk.py
@@ -73,6 +73,7 @@ def proc_host(host: str, timeout: int, ssl: bool) -> None:
     print('[*] Processing host:', host)
     global writer
     allpaths = list()
+    issuecounter = 0
 
     for fp in fingerprints:
         if isinstance(fp['path'], list):
@@ -90,7 +91,10 @@ def proc_host(host: str, timeout: int, ssl: bool) -> None:
 
         if xfresp:
             print('[!] Found potential issue on %s: %s' % (host, xfresp[0]))
+            issuecounter += 1
             writer.writerow([host, path, xfresp[0], xfresp[1], xfresp[2]])
+
+    print('[*] %s issues found on %s' % (issuecounter, host))
 
 def process_hosts(hosts: list, concurrency: int, timeout: int, ssl: bool) -> None:
     '''


### PR DESCRIPTION
During script execution not much information is provided about the amount of detected issues. If no issues are detected, there's no information about that either and the file is still generated, though only with column headers. It can be a bit confusing because this may also give an impression about script not working properly for example.

I have added additional logging information that will display information about how many issues were detected per host. If no issues will be detected, it will just state the "0 issues were found for [HOST]".

@0xInfection FYI 😊